### PR TITLE
edit-migrate_devise_create_users.rb

### DIFF
--- a/db/migrate/20170201060056_devise_create_users.rb
+++ b/db/migrate/20170201060056_devise_create_users.rb
@@ -19,11 +19,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.0]
       t.string   :current_sign_in_ip
       t.string   :last_sign_in_ip
 
-      ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      # Confirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts


### PR DESCRIPTION
##What
migrationファイルの＃Confirmableセクションのコメントアウトを外す

##Why
認証メールのトークンや再送信の情報を保存するカラムを追加するため